### PR TITLE
Moved functions to util, changed simulation, added plotting

### DIFF
--- a/qtree/simulation.py
+++ b/qtree/simulation.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jan  4 11:36:26 2021
+@author: Johannes
+QTree Simulationstudy
+Testing QTree without Parameter Selection for various Parameters
+  Parameters
+  ----------
+  rep_n: Number of repetitions
+  d_n= Number of Nodes
+  n_n= Number of Observations
+  noise_to_signal_n: Noise to Signal Ratio
+  c1: Minimum Edge weight (in max-times model)
+  c2: Maximum Edge weight (in max-times model)
+  v: Shape Parameter of the Frechet Distribution
+    
+  Returns
+  -------
+  Saves Results in the folder output/QTreeSim:
+      
+  Scores: list of dictionaries of all mean scores
+  
+  (G_true,G_est,score): (numpy array,numpy array,dict)
+  
+  G_true: True underlying Graph
+  G_est: Estimated underlying Graph
+  score: Dict of metrics between G_true and G_est: fdr (False Discovery Rate), tpr (True Positive Rate)
+         fpr (False Positive Rate), shd (Normalized Structural Hamming Distance) as well as 
+         fdr_r, tpr_r, fpr_r and shd_r for the metrics of the respective reachability graphs
+"""
+
+import os
+from QTree import QTree
+from utils import saveTo, count_accuracy, create_sa, kleene, MLMatrixMult
+import pandas as pd
+import scipy.stats as st
+import numpy as np
+
+
+
+
+if __name__ == "__main__":
+
+  np.random.seed(1) #fix seed
+  #set parameters
+  rep_n=100
+
+  d_n=[10,30,50,100]
+  n_n=[10,25,50, 100,200, 500, 1000]
+  noise_to_signal_n=[0.1,0.2,0.3]
+
+  c1=0.2
+  c2=1
+
+  #shape
+  v=1
+  scores=[]
+  keys=['fdr', 'tpr', 'fpr', 'shd', 'fdr_r', 'tpr_r', 'fpr_r', 'shd_r'] 
+  
+  for rep in range(rep_n):
+      
+      for idx_d,d in enumerate(d_n):
+          C=create_sa(d,c1,c2)
+          B=kleene(C)
+          G_true=C>0
+
+          for idx_n,n in enumerate(n_n):
+              Z=st.invweibull.rvs(v, 0, 1, size=(n,d))
+              X=MLMatrixMult(Z,B)
+              sample_std=np.median(np.std(X,0))
+
+              for idx_noise_to_signal, noise_to_signal in enumerate(noise_to_signal_n):
+                  noise=np.random.normal(loc=0.0, scale=(noise_to_signal*sample_std), size=(n,d))
+                  Y=X+noise
+
+                  estimator = QTree(q=0)
+                  G_est=estimator.fit(pd.DataFrame(Y))
+
+                  save_folder=os.path.join('output/QTreeSim','qtree_rep_'+str(rep)+'_d_'+str(d)+'_n_'+str(n)+'_noise_'+str(noise_to_signal))
+                  if save_folder is not None:
+                      obj = (G_true,G_est,count_accuracy(G_true,[G_est])[0])  
+                      fname = 'output'+ ".pk"
+                      saveTo(obj, save_folder,fname)
+                      
+                      
+                  score = {k: v / rep_n for k, v in count_accuracy(G_true,[G_est])[0].items()}
+                  score.update({'d':d,'n':n,'noise': noise_to_signal})
+                  
+                  if not [s for s in scores if s['d'] == d and s['n']==n and s['noise']==noise_to_signal]:
+                      scores+=[score]
+                      continue
+                                   
+                  for s in scores:
+                      if s['d']==d and s['n']==n and s['noise']==noise_to_signal:
+                          for k in keys:
+                              s.update({k:s[k]+score[k]})
+    
+  save_folder='output/QTreeSim'     
+  if save_folder is not None:
+      fname = 'Scores'+ ".pk"
+      saveTo(scores, save_folder,fname)

--- a/qtree/simulationplot.py
+++ b/qtree/simulationplot.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jan  4 11:36:26 2021
+@author: Johannes
+Plot the Results of the QTree Simulationstudy
+  Parameters
+  ----------
+  metric: Metric to plot - can be 'fdr', 'tpr', 'fpr' and 'shd'
+  noise= Noise to Signal Ratio; Default values used in the simulation study are 0.1, 0.2 and 0.3
+    
+  Returns
+  -------
+  Saves Plot in the folder output/QTreeSim:
+      
+  metric.png: Figure plotting (n,metric) for all sample sizes n. Different graph sizes d are plotted 
+              separately, solid lines plot the metric of the graph, dashed lines of the reachability graph
+"""
+
+import pickle
+import os
+import matplotlib.pyplot as plt
+import matplotlib
+import sys
+
+if __name__ == "__main__":
+    
+   metric='shd'   
+   noise=0.3    
+   
+   save_folder='output/QTreeSim'
+
+   with open(os.path.join(save_folder, 'Scores.pk'), 'rb') as file_name:
+       scores  = pickle.load(file_name)
+
+   d_n= list(dict.fromkeys([s['d'] for s in scores]))
+   n_n= list(dict.fromkeys([s['n'] for s in scores]))
+   noise_to_signal_n= list(dict.fromkeys([s['noise'] for s in scores]))
+   
+   
+   if noise not in noise_to_signal_n:
+       print("Value of noise not found in scores")
+       sys.exit() 
+
+   fig, axs = plt.subplots(len(d_n)//2, 2)
+   
+   for idx_d,d in enumerate(d_n):
+       
+       graph=[]
+       reach=[]
+       
+       for idx_n,n in enumerate(n_n):
+                 graph+=[[s for s in scores if s['d'] == d and s['n']==n and s['noise']==noise][0][metric]] 
+                 reach+=[[s for s in scores if s['d'] == d and s['n']==n and s['noise']==noise][0][metric+'_r']]
+                       
+       axs[idx_d//2, idx_d%2].plot(n_n, graph,color='midnightblue', linestyle='solid', marker='o')
+       axs[idx_d//2, idx_d%2].plot(n_n, reach,color='midnightblue', linestyle='dashed', marker='o')
+       axs[idx_d//2, idx_d%2].set_xscale('log')
+       axs[idx_d//2, idx_d%2].set_xticks(n_n)
+       axs[idx_d//2, idx_d%2].get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())
+       axs[idx_d//2, idx_d%2].set_xlabel('Sample Size',fontweight="bold")
+       axs[idx_d//2, idx_d%2].legend([metric, metric+'_r'])
+       axs[idx_d//2, idx_d%2].set_title(metric + " for d = " + str(d), fontweight="bold")
+   plt.tight_layout()
+   plt.close(fig)
+   fig.savefig(save_folder+'/'+metric+'.png', dpi=300) 
+
+


### PR DESCRIPTION
Hi Ngoc,

so I am sure I did not do it the intended way of updating the pull request but I accidentally created a new one; 

Anyway, I accepted your edits, (except that one indent was wrong and you deleted one necessary line), I removed the progress print, moved the three functions to util, changed the name of the function fromCtoB and extended the output of simulation.py (it now also outputs Scores.pk which is a list of dictionaries of mean scores);

Also, I of course added simulationplot.py which reads the Scores.pk, reads all values for d, n, and noise-to-signal ratio and takes two arguments; The metric, for example 'shd' and the noise to signal ratio and then plots the specific metric against the sample size n for all d; It replicates Figure 2 and 3 of the appendix but of course can also create other plots of other metrics 